### PR TITLE
Fix the build by adding curl to the build container

### DIFF
--- a/Build.Dockerfile
+++ b/Build.Dockerfile
@@ -3,7 +3,7 @@ FROM golang:1.6.2-alpine
 MAINTAINER Alexei Ledenev <alexei.led@gmail.com>
 
 # install Git apk
-RUN apk --update add git bash \
+RUN apk --update add git bash curl \
     && rm -rf /var/lib/apt/lists/* \
     && rm /var/cache/apk/*
 


### PR DESCRIPTION
Current alpine versions no longer ship curl by default, so this needs to be installed manually during the build