### PR TITLE
Add basic capability to disrupt container network

### DIFF
--- a/Build.Dockerfile
+++ b/Build.Dockerfile
@@ -3,7 +3,7 @@ FROM golang:1.6.2-alpine
 MAINTAINER Alexei Ledenev <alexei.led@gmail.com>
 
 # install Git apk
-RUN apt-get update && apt-get install curl && apk --update add git bash \
+RUN apk --update add git bash curl \
     && rm -rf /var/lib/apt/lists/* \
     && rm /var/cache/apk/*
 

--- a/Build.Dockerfile
+++ b/Build.Dockerfile
@@ -3,7 +3,7 @@ FROM golang:1.6.2-alpine
 MAINTAINER Alexei Ledenev <alexei.led@gmail.com>
 
 # install Git apk
-RUN apk-get update && apk-get install curl && apk --update add git bash \
+RUN apt-get update && apt-get install curl && apk --update add git bash \
     && rm -rf /var/lib/apt/lists/* \
     && rm /var/cache/apk/*
 

--- a/Build.Dockerfile
+++ b/Build.Dockerfile
@@ -3,7 +3,7 @@ FROM golang:1.6.2-alpine
 MAINTAINER Alexei Ledenev <alexei.led@gmail.com>
 
 # install Git apk
-RUN apk --update add git bash \
+RUN apk-get update && apk-get install curl && apk --update add git bash \
     && rm -rf /var/lib/apt/lists/* \
     && rm /var/cache/apk/*
 

--- a/README.md
+++ b/README.md
@@ -50,13 +50,13 @@ USAGE:
    pumba run [command options] [arguments...]
 
 OPTIONS:
-   --chaos, -c [--chaos option --chaos option]	chaos command: `container(s,)/re2:regex|interval(s/m/h postfix)|STOP/KILL(:SIGNAL)/RM/DISRUPT(:netem command)`
+   --chaos, -c [--chaos option --chaos option]	chaos command: `container(s,)/re2:regex|interval(s/m/h postfix)|STOP/KILL(:SIGNAL)/RM/DISRUPT(:netem command)(:target ip)`
    --random, -r					Random mode: randomly select single matching container as a target for the specified chaos action
 ```
 
 ### Using Pumba to disrupt containers network
 
-For testing your containers under specific network conditions, Pumba is using the linux [Network Emulation driver](http://www.linuxfoundation.org/collaborate/workgroups/networking/netem). As described, these commands affect the outgoing network traffic (egress), so for example, one may disrupt the backend API service or data service and then test the frontend to see the implications.
+For testing your containers under specific network conditions, Pumba is using the linux [Network Emulation driver](http://www.linuxfoundation.org/collaborate/workgroups/networking/netem). As described in the above link, these commands affect the outgoing network traffic (egress), so for example, one may disrupt the backend API service or data service and then test the frontend to see the implications. In order to disrupt communication between specific containers, use the DISRUPT option to specifiy target container IP - Pumba will then filter the outgoing traffic and apply the netem effect only to the traffic going to the specific IP.
 
 A few implementaion points are important to understand:
 * Netem commands are executed on containers using 'docker exec'. In order to change network driver settings, the container must have NET_ADMIN capability - this can be granted via the ['docker run' command](https://docs.docker.com/engine/reference/run/#/runtime-privilege-and-linux-capabilities), via [docker-compose.yml](https://docs.docker.com/compose/compose-file/#/cap-add-cap-drop) or otherwise.

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ VERSION:
    0.1.10
 
 COMMANDS:
-    run  Pumba starts making chaos: periodically (and randomly) kills/stops/remove specified containers
+    run  Pumba starts making chaos: periodically (and/or randomly) executes specified chaos actions on specified containers
 
 GLOBAL OPTIONS:
    --host, -H "unix:///var/run/docker.sock"  daemon socket to connect to [$DOCKER_HOST]
@@ -44,15 +44,25 @@ GLOBAL OPTIONS:
 $ pumba run --help
 
 NAME:
-   pumba run - Pumba starts making chaos: periodically (and randomly) kills/stops/remove specified containers
+   pumba run - Pumba starts making chaos: periodically (and/or randomly) executes specified chaos actions on specified containers
 
 USAGE:
    pumba run [command options] [arguments...]
 
 OPTIONS:
-   --chaos, -c [--chaos option --chaos option]	chaos command: `container(s,)/re2:regex|interval(s/m/h postfix)|STOP/KILL(:SIGNAL)/RM`
-   --random, -r					Random mode: randomly select single matching container to 'kill'
+   --chaos, -c [--chaos option --chaos option]	chaos command: `container(s,)/re2:regex|interval(s/m/h postfix)|STOP/KILL(:SIGNAL)/RM/DISRUPT(:netem command)`
+   --random, -r					Random mode: randomly select single matching container as a target for the specified chaos action
 ```
+
+### Using Pumba to disrupt containers network
+
+For testing your containers under specific network conditions, Pumba is using the linux [Network Emulation driver](http://www.linuxfoundation.org/collaborate/workgroups/networking/netem). As described, these commands affect the outgoing network traffic (egress), so for example, one may disrupt the backend API service or data service and then test the frontend to see the implications.
+Netem commands are executed on containers using 'docker exec'.
+
+USAGE:
+   pumba run container-name|10m|DISRUPT:delay 100ms
+   
+   Pumba will run 'docker exec' every 10 minutes on container 'container-name' to add the netem driver to eth0 with a delay of 100ms on outgoing traffic
 
 ### Runing inside Docker container
 

--- a/README.md
+++ b/README.md
@@ -82,7 +82,6 @@ Pass `KILL:{SIGNALNAME}` (without braces) to Pumba though `chaos` option, and Pu
 #### PAUSE
 
 `PAUSE` command will pause all processes running inside Docker container for specified interval. The command syntax: `PAUSE:INTERVAL`. Pause interval is just a number with optional postfix: `s, m or h`.
->>>>>>> upstream/master
 
 #### DISRUPT command - using Pumba to disrupt containers network
 

--- a/README.md
+++ b/README.md
@@ -59,11 +59,12 @@ OPTIONS:
 For testing your containers under specific network conditions, Pumba is using the linux [Network Emulation driver](http://www.linuxfoundation.org/collaborate/workgroups/networking/netem). As described, these commands affect the outgoing network traffic (egress), so for example, one may disrupt the backend API service or data service and then test the frontend to see the implications.
 Netem commands are executed on containers using 'docker exec'.
 
+```
 USAGE:
    pumba run container-name|10m|DISRUPT:delay 100ms
    
    Pumba will run 'docker exec' every 10 minutes on container 'container-name' to add the netem driver to eth0 with a delay of 100ms on outgoing traffic
-
+```
 ### Runing inside Docker container
 
 If you choose to use Pumba Docker [image](https://hub.docker.com/r/gaiaadm/pumba/) on Linux, use the following command:

--- a/README.md
+++ b/README.md
@@ -66,12 +66,12 @@ A few implementaion points are important to understand:
 ```
 * Generally, repeating the same disruption to the network of the same container has no effect. In a way, it will be best to use DISRUPT in random mode, combined with KILL so that disrupted containers will be removed from time to time.
 
-USAGE:
+Example:
 ```
    pumba run container-name|10m|DISRUPT:delay 100ms
    
 ```
-   Pumba will run 'docker exec' every 10 minutes on container 'container-name' to add the netem driver to eth0 with a delay of 100ms on outgoing traffic
+Pumba will run 'docker exec' every 10 minutes on container 'container-name' to add the netem driver to eth0 with a delay of 100ms on outgoing traffic
 
 ### Runing inside Docker container
 

--- a/action/chaos.go
+++ b/action/chaos.go
@@ -160,14 +160,14 @@ func disruptContainers(client container.Client, containers []container.Container
 	if RandomMode {
 		container := randomContainer(containers)
 		if container != nil {
-			err := client.DisruptContainer(*container, DryMode, netemCmd)
+			err := client.DisruptContainer(*container, netemCmd, DryMode)
 			if err != nil {
 				return err
 			}
 		}
 	} else {
 		for _, container := range containers {
-			err := client.DisruptContainer(container, DryMode, netemCmd)
+			err := client.DisruptContainer(container, netemCmd, DryMode)
 			if err != nil {
 				return err
 			}

--- a/action/chaos.go
+++ b/action/chaos.go
@@ -29,13 +29,10 @@ type Chaos interface {
 	KillByPattern(container.Client, string, string) error
 	RemoveByName(container.Client, []string, bool) error
 	RemoveByPattern(container.Client, string, bool) error
-<<<<<<< HEAD
 	DisruptByName(container.Client, []string, string) error
 	DisruptByPattern(container.Client, string, string) error
-=======
 	PauseByName(container.Client, []string, string) error
 	PauseByPattern(container.Client, string, string) error
->>>>>>> upstream/master
 }
 
 // Pumba makes chaos

--- a/action/chaos.go
+++ b/action/chaos.go
@@ -156,18 +156,18 @@ func removeContainers(client container.Client, containers []container.Container,
 	return nil
 }
 
-func disruptContainers(client container.Client, containers []container.Container) error {
+func disruptContainers(client container.Client, containers []container.Container, netemCmd string) error {
 	if RandomMode {
 		container := randomContainer(containers)
 		if container != nil {
-			err := client.DisruptContainer(*container, DryMode)
+			err := client.DisruptContainer(*container, DryMode, netemCmd)
 			if err != nil {
 				return err
 			}
 		}
 	} else {
 		for _, container := range containers {
-			err := client.DisruptContainer(container, DryMode)
+			err := client.DisruptContainer(container, DryMode, netemCmd)
 			if err != nil {
 				return err
 			}

--- a/action/chaos.go
+++ b/action/chaos.go
@@ -29,8 +29,8 @@ type Chaos interface {
 	KillByPattern(container.Client, string, string) error
 	RemoveByName(container.Client, []string, bool) error
 	RemoveByPattern(container.Client, string, bool) error
-	DisruptByName(container.Client, []string, bool) error
-	DisruptByPattern(container.Client, string, bool) error
+	DisruptByName(container.Client, []string) error
+	DisruptByPattern(container.Client, string) error
 }
 
 // Pumba makes chaos
@@ -253,7 +253,7 @@ func (p Pumba) DisruptByName(client container.Client, names []string) error {
 	return disruptContainers(client, containers)
 }
 
-// DisruptByName disrupts container egress network, if its name matches 'pattern'. 
+// DisruptByPattern disrupts container egress network, if its name matches 'pattern'. 
 // Disruption is currently limited to delayed response
 func (p Pumba) DisruptByPattern(client container.Client, pattern string) error {
 	log.Infof("Disrupt containers by RE2 pattern: '%s'", pattern)

--- a/action/chaos.go
+++ b/action/chaos.go
@@ -29,8 +29,8 @@ type Chaos interface {
 	KillByPattern(container.Client, string, string) error
 	RemoveByName(container.Client, []string, bool) error
 	RemoveByPattern(container.Client, string, bool) error
-	DisruptByName(container.Client, []string) error
-	DisruptByPattern(container.Client, string) error
+	DisruptByName(container.Client, []string, string) error
+	DisruptByPattern(container.Client, string, string) error
 }
 
 // Pumba makes chaos
@@ -244,22 +244,22 @@ func (p Pumba) RemoveByPattern(client container.Client, pattern string, force bo
 
 // DisruptByName disrupts container egress network, if its name within `names`. 
 // Disruption is currently limited to delayed response
-func (p Pumba) DisruptByName(client container.Client, names []string) error {
+func (p Pumba) DisruptByName(client container.Client, names []string, netemCmd string) error {
 	log.Info("Disrupt containers by names: ", names)
 	containers, err := client.ListContainers(containerFilter(names))
 	if err != nil {
 		return err
 	}
-	return disruptContainers(client, containers)
+	return disruptContainers(client, containers, netemCmd)
 }
 
 // DisruptByPattern disrupts container egress network, if its name matches 'pattern'. 
 // Disruption is currently limited to delayed response
-func (p Pumba) DisruptByPattern(client container.Client, pattern string) error {
+func (p Pumba) DisruptByPattern(client container.Client, pattern string, netemCmd string) error {
 	log.Infof("Disrupt containers by RE2 pattern: '%s'", pattern)
 	containers, err := client.ListContainers(regexContainerFilter(pattern))
 	if err != nil {
 		return err
 	}
-	return disruptContainers(client, containers)
+	return disruptContainers(client, containers, netemCmd)
 }

--- a/container/client.go
+++ b/container/client.go
@@ -188,7 +188,7 @@ func (client dockerClient) DisruptContainer(c Container, netemCmd string, dryrun
 		// http://www.linuxfoundation.org/collaborate/workgroups/networking/netem
 		netemBase := strings.Split("tc qdisc add dev eth0 root netem", " ")
 		netemCommand := strings.Split(strings.ToLower(netemCmd), " ")
-		netemMerge := append(netemBase, netemSplit)
+		netemMerge := append(netemBase, netemCommand)
 		execConfig := &dockerclient.ExecConfig{
 			Cmd: netemMerge,
 			Container: c.ID(),

--- a/container/client.go
+++ b/container/client.go
@@ -196,7 +196,7 @@ func (client dockerClient) DisruptContainer(c Container, netemCmd string, dryrun
 				return err
 			}
 
-		log.Debugf("Starting Exec %s (%s)", netemMerge, _id)
+		log.Debugf("Starting Exec %s (%s)", netemCommand, _id)
 		return client.api.ExecStart(_id, execConfig)
 	}
 	return nil

--- a/container/client.go
+++ b/container/client.go
@@ -194,7 +194,7 @@ func (client dockerClient) DisruptContainer(c Container, dryrun bool) error {
 				return err
 			}
 
-		log.Debugf("Starting Exec %s (%s)", name, _id)
+		log.Debugf("Starting Exec %s (%s)", "netem", _id)
 		return client.api.ExecStart(_id, execConfig)
 	}
 	return nil

--- a/container/client.go
+++ b/container/client.go
@@ -186,7 +186,7 @@ func (client dockerClient) DisruptContainer(c Container, netemCmd string, dryrun
 		// use dockerclient ExecStart to run Traffic Control:
 		// 'tc qdisc add dev eth0 root netem delay 100ms'
 		// http://www.linuxfoundation.org/collaborate/workgroups/networking/netem
-		netemCommand := "tc qdisc add dev eth0 root netem " + netemCmd
+		netemCommand := "tc qdisc add dev eth0 root netem " + strings.ToLower(netemCmd)
 		execConfig := &dockerclient.ExecConfig{
 			Cmd: strings.Split(netemCommand, " "),
 			Container: c.ID(),

--- a/container/client.go
+++ b/container/client.go
@@ -181,8 +181,7 @@ func (client dockerClient) DisruptContainer(c Container, netemCmd string, dryrun
 	cmd = strings.Split(netemCmd, ":")
 	if len(cmd) == 2 {
 		return disruptContainerFilterNetwork(c, cmd[0], cmd[1], dryrun)
-	}
-	else {// all network
+	} else {// all network
 		return disruptContainerAllNetwork(c, cmd[0], dryrun)
 	}
 }

--- a/container/client.go
+++ b/container/client.go
@@ -186,11 +186,9 @@ func (client dockerClient) DisruptContainer(c Container, netemCmd string, dryrun
 		// use dockerclient ExecStart to run Traffic Control:
 		// 'tc qdisc add dev eth0 root netem delay 100ms'
 		// http://www.linuxfoundation.org/collaborate/workgroups/networking/netem
-		netemBase := strings.Split("tc qdisc add dev eth0 root netem", " ")
-		netemCommand := strings.Split(strings.ToLower(netemCmd), " ")
-		netemMerge := append(netemBase, netemCommand)
+		netemCommand := "tc qdisc add dev eth0 root netem " + netemCmd
 		execConfig := &dockerclient.ExecConfig{
-			Cmd: netemMerge,
+			Cmd: strings.Split(netemCommand, " "),
 			Container: c.ID(),
 		}
 		_id, err := client.api.ExecCreate(execConfig)

--- a/container/client.go
+++ b/container/client.go
@@ -28,7 +28,7 @@ type Client interface {
 	RenameContainer(Container, string) error
 	RemoveImage(Container, bool, bool) error
 	RemoveContainer(Container, bool, bool) error
-	DisruptContainer(Container, bool) error
+	DisruptContainer(Container, string, bool) error
 }
 
 // NewClient returns a new Client instance which can be used to interact with

--- a/container/client.go
+++ b/container/client.go
@@ -185,17 +185,17 @@ func (client dockerClient) DisruptContainer(c Container, dryrun bool) error {
 		// use dockerclient ExecStart to run Traffic Control:
 		// 'tc qdisc add dev eth0 root netem delay 100ms'
 		// http://www.linuxfoundation.org/collaborate/workgroups/networking/netem
-		execConfig := dockerclient.ExecConfig{
+		execConfig := &dockerclient.ExecConfig{
 			Cmd: []string{"tc", "qdisc", "add", "dev", "eth0", "root", "netem", "delay", "100ms"},
-			Container: c.ID()
+			Container: c.ID(),
 		}
-		_id, err := client.api.ExecCreate(&execConfig)
+		_id, err := client.api.ExecCreate(execConfig)
 		if err != nil {
 				return err
 			}
 
 		log.Debugf("Starting Exec %s (%s)", name, _id)
-		return client.api.ExecStart(_id, &execConfig)
+		return client.api.ExecStart(_id, execConfig)
 	}
 	return nil
 }

--- a/container/client.go
+++ b/container/client.go
@@ -177,7 +177,6 @@ func (client dockerClient) RemoveContainer(c Container, force bool, dryrun bool)
 	return nil
 }
 
-<<<<<<< HEAD
 func (client dockerClient) DisruptContainer(c Container, netemCmd string, dryrun bool) error {
 	// find out if we have command, ip or command:ip
 	cmd := strings.Split(netemCmd, ":")

--- a/container/client.go
+++ b/container/client.go
@@ -186,8 +186,9 @@ func (client dockerClient) DisruptContainer(c Container, netemCmd string, dryrun
 		// use dockerclient ExecStart to run Traffic Control:
 		// 'tc qdisc add dev eth0 root netem delay 100ms'
 		// http://www.linuxfoundation.org/collaborate/workgroups/networking/netem
-		netemSplit := strings.Split(strings.ToLower(netemCmd), " ")
-		netemMerge := append(netemSplit, []string{"tc", "qdisc", "add", "dev", "eth0", "root", "netem"})
+		netemBase := strings.Split("tc qdisc add dev eth0 root netem", " ")
+		netemCommand := strings.Split(strings.ToLower(netemCmd), " ")
+		netemMerge := append(netemBase, netemSplit, ...)
 		execConfig := &dockerclient.ExecConfig{
 			Cmd: netemMerge,
 			Container: c.ID(),

--- a/container/client.go
+++ b/container/client.go
@@ -221,12 +221,14 @@ func (client dockerClient) disruptContainerFilterNetwork(c Container, netemCmd s
 		//  u32 match ip dst 172.19.0.3 flowid 1:3'
 		// http://www.linuxfoundation.org/collaborate/workgroups/networking/netem
 		handleCommand := "tc qdisc add dev eth0 root handle 1: prio"
+		log.Debugf("Disrupt with handleCommand %s", handleCommand)
 		err := client.execOnContainer(c, handleCommand)
 		if err != nil {
 				return err
 			}
 
 		netemCommand := "tc qdisc add dev eth0 parent 1:3 netem " + strings.ToLower(netemCmd)
+		log.Debugf("Disrupt with netemCommand %s", netemCommand)
 		err = client.execOnContainer(c, netemCommand)
 		if err != nil {
 				return err
@@ -234,6 +236,7 @@ func (client dockerClient) disruptContainerFilterNetwork(c Container, netemCmd s
 
 		filterCommand := "tc filter add dev eth0 protocol ip parent 1:0 prio 3 "+
 			"u32 match ip dst " + strings.ToLower(targetIP) + " flowid 1:3"
+		log.Debugf("Disrupt with filterCommand %s", filterCommand)
 		return client.execOnContainer(c, filterCommand)
 	}
 	return nil

--- a/container/client.go
+++ b/container/client.go
@@ -181,7 +181,7 @@ func (client dockerClient) DisruptContainer(c Container, netemCmd string, dryrun
 	cmd = strings.Split(netemCmd, ":")
 	if len(cmd) == 2 {
 		return disruptContainerFilterNetwork(c, cmd[0], cmd[1], dryrun)
-	} else {// all network
+	} else {
 		return disruptContainerAllNetwork(c, cmd[0], dryrun)
 	}
 }

--- a/container/client.go
+++ b/container/client.go
@@ -4,6 +4,7 @@ import (
 	"crypto/tls"
 	"fmt"
 	"time"
+	"strings"
 
 	log "github.com/Sirupsen/logrus"
 	"github.com/samalba/dockerclient"

--- a/container/client.go
+++ b/container/client.go
@@ -221,15 +221,15 @@ func (client dockerClient) disruptContainerFilterNetwork(c Container, netemCmd s
 		//  u32 match ip dst 172.19.0.3 flowid 1:3'
 		// http://www.linuxfoundation.org/collaborate/workgroups/networking/netem
 		handleCommand := "tc qdisc add dev eth0 root handle 1: prio"
-		err_handle := client.execOnContainer(c, handleCommand)
-		if err_handle != nil {
-				return err_handle
+		err := client.execOnContainer(c, handleCommand)
+		if err != nil {
+				return err
 			}
 
 		netemCommand := "tc qdisc add dev eth0 parent 1:3 netem " + strings.ToLower(netemCmd)
-		err_netem := client.execOnContainer(c, netemCommand)
-		if err_netem != nil {
-				return err_netem
+		err = client.execOnContainer(c, netemCommand)
+		if err != nil {
+				return err
 			}
 
 		filterCommand := "tc filter add dev eth0 protocol ip parent 1:0 prio 3 "+

--- a/container/client.go
+++ b/container/client.go
@@ -188,7 +188,7 @@ func (client dockerClient) DisruptContainer(c Container, netemCmd string, dryrun
 		// http://www.linuxfoundation.org/collaborate/workgroups/networking/netem
 		netemBase := strings.Split("tc qdisc add dev eth0 root netem", " ")
 		netemCommand := strings.Split(strings.ToLower(netemCmd), " ")
-		netemMerge := append(netemBase, netemSplit, ...)
+		netemMerge := append(netemBase, netemSplit)
 		execConfig := &dockerclient.ExecConfig{
 			Cmd: netemMerge,
 			Container: c.ID(),

--- a/container/client.go
+++ b/container/client.go
@@ -182,8 +182,7 @@ func (client dockerClient) DisruptContainer(c Container, netemCmd string, dryrun
 	if len(cmd) == 2 {
 		return disruptContainerFilterNetwork(c, cmd[0], cmd[1], dryrun)
 	}
-	else // all network
-	{
+	else {// all network
 		return disruptContainerAllNetwork(c, cmd[0], dryrun)
 	}
 }
@@ -223,15 +222,15 @@ func (client dockerClient) disruptContainerFilterNetwork(c Container, netemCmd s
 		//  u32 match ip dst 172.19.0.3 flowid 1:3'
 		// http://www.linuxfoundation.org/collaborate/workgroups/networking/netem
 		handleCommand := "tc qdisc add dev eth0 root handle 1: prio"
-		err := execOnContainer(c, handleCommand)
-		if err != nil {
-				return err
+		err_handle := execOnContainer(c, handleCommand)
+		if err_handle != nil {
+				return err_handle
 			}
 
 		netemCommand := "tc qdisc add dev eth0 parent 1:3 netem " + strings.ToLower(netemCmd)
-		err := execOnContainer(c, netemCommand)
-		if err != nil {
-				return err
+		err_netem := execOnContainer(c, netemCommand)
+		if err_netem != nil {
+				return err_netem
 			}
 
 		filterCommand := "tc filter add dev eth0 protocol ip parent 1:0 prio 3 "+

--- a/container/client_test.go
+++ b/container/client_test.go
@@ -542,9 +542,9 @@ func TestDisruptContainer_Success(t *testing.T) {
 	}
 
 	api := mockclient.NewMockClient()
-	api.On("DisruptContainer", "abc123", "delay 1000ms").Return(nil)
 	api.On("ExecCreate", mock.Anything).Return(nil)
 	api.On("ExecStart", "abc123", mock.Anything).Return(nil)
+	api.On("DisruptContainer", "abc123", "delay 1000ms").Return(nil)
 
 	client := dockerClient{api: api}
 	err := client.DisruptContainer(c, "delay 1000ms", false)
@@ -566,7 +566,7 @@ func TestDisruptContainer_DryRun(t *testing.T) {
 	err := client.DisruptContainer(c, "delay 1000ms", true)
 
 	assert.NoError(t, err)
-	api.AssertNotCalled(t, "DisruptContainer", "abc123","delay 1000ms")
 	api.AssertNotCalled(t, "ExecCreate", mock.Anything)
-	api.AssertNotCalled(t, "ExecStart", mock.Anything, mock.Anything)
+	api.AssertNotCalled(t, "ExecStart", "abc123", mock.Anything)
+	api.AssertNotCalled(t, "DisruptContainer", "abc123","delay 1000ms")
 }

--- a/container/client_test.go
+++ b/container/client_test.go
@@ -544,7 +544,6 @@ func TestDisruptContainer_Success(t *testing.T) {
 	api := mockclient.NewMockClient()
 	api.On("ExecCreate", mock.Anything).Return("abc123", nil)
 	api.On("ExecStart", "abc123", mock.Anything).Return(nil)
-	api.On("DisruptContainer", "abc123", "delay 1000ms").Return(nil)
 
 	client := dockerClient{api: api}
 	err := client.DisruptContainer(c, "delay 1000ms", false)
@@ -568,5 +567,4 @@ func TestDisruptContainer_DryRun(t *testing.T) {
 	assert.NoError(t, err)
 	api.AssertNotCalled(t, "ExecCreate", mock.Anything)
 	api.AssertNotCalled(t, "ExecStart", "abc123", mock.Anything)
-	api.AssertNotCalled(t, "DisruptContainer", "abc123","delay 1000ms")
 }

--- a/container/client_test.go
+++ b/container/client_test.go
@@ -533,3 +533,37 @@ func TestPauseContainer_UnpauseError(t *testing.T) {
 	assert.EqualError(t, err, "unpause")
 	api.AssertExpectations(t)
 }
+
+func TestDisruptContainer_Success(t *testing.T) {
+	c := Container{
+		containerInfo: &dockerclient.ContainerInfo{
+			Id: "abc123",
+		},
+	}
+
+	api := mockclient.NewMockClient()
+	api.On("DisruptContainer", "abc123", "delay 1000ms").Return(nil)
+
+	client := dockerClient{api: api}
+	err := client.DisruptContainer(c, "delay 1000ms", false)
+
+	assert.NoError(t, err)
+	api.AssertExpectations(t)
+}
+
+func TestDisruptContainer_DryRun(t *testing.T) {
+	c := Container{
+		containerInfo: &dockerclient.ContainerInfo{
+			Id: "abc123",
+		},
+	}
+
+	api := mockclient.NewMockClient()
+	api.On("DisruptContainer", "abc123", "delay 1000ms").Return(nil)
+
+	client := dockerClient{api: api}
+	err := client.DisruptContainer(c, "delay 1000ms", true)
+
+	assert.NoError(t, err)
+	api.AssertNotCalled(t, "DisruptContainer", "abc123","delay 1000ms")
+}

--- a/container/client_test.go
+++ b/container/client_test.go
@@ -542,8 +542,8 @@ func TestDisruptContainer_Success(t *testing.T) {
 	}
 
 	api := mockclient.NewMockClient()
-	api.On("ExecCreate", mock.Anything).Return(nil)
-	//api.On("ExecStart", "abc123", mock.Anything).Return(nil)
+	api.On("ExecCreate", mock.Anything).Return("abc123")
+	api.On("ExecStart", "abc123", mock.Anything).Return(nil)
 	api.On("DisruptContainer", "abc123", "delay 1000ms").Return(nil)
 
 	client := dockerClient{api: api}

--- a/container/client_test.go
+++ b/container/client_test.go
@@ -542,7 +542,7 @@ func TestDisruptContainer_Success(t *testing.T) {
 	}
 
 	api := mockclient.NewMockClient()
-	api.On("ExecCreate", mock.Anything).Return("abc123")
+	api.On("ExecCreate", mock.Anything).Return("abc123", nil)
 	api.On("ExecStart", "abc123", mock.Anything).Return(nil)
 	api.On("DisruptContainer", "abc123", "delay 1000ms").Return(nil)
 

--- a/container/client_test.go
+++ b/container/client_test.go
@@ -543,7 +543,7 @@ func TestDisruptContainer_Success(t *testing.T) {
 
 	api := mockclient.NewMockClient()
 	api.On("ExecCreate", mock.Anything).Return(nil)
-	api.On("ExecStart", "abc123", mock.Anything).Return(nil)
+	//api.On("ExecStart", "abc123", mock.Anything).Return(nil)
 	api.On("DisruptContainer", "abc123", "delay 1000ms").Return(nil)
 
 	client := dockerClient{api: api}

--- a/container/client_test.go
+++ b/container/client_test.go
@@ -544,7 +544,7 @@ func TestDisruptContainer_Success(t *testing.T) {
 	api := mockclient.NewMockClient()
 	api.On("DisruptContainer", "abc123", "delay 1000ms").Return(nil)
 	api.On("ExecCreate", mock.Anything).Return(nil)
-	api.On("ExecStart", mock.Anything, mock.Anything).Return(nil)
+	api.On("ExecStart", "abc123", mock.Anything).Return(nil)
 
 	client := dockerClient{api: api}
 	err := client.DisruptContainer(c, "delay 1000ms", false)

--- a/container/client_test.go
+++ b/container/client_test.go
@@ -542,7 +542,7 @@ func TestDisruptContainer_Success(t *testing.T) {
 	}
 
 	api := mockclient.NewMockClient()
-	api.On("ExecCreate", mock.Anything).Return(nil)
+	//api.On("ExecCreate", mock.Anything).Return(nil)
 	//api.On("ExecStart", "abc123", mock.Anything).Return(nil)
 	api.On("DisruptContainer", "abc123", "delay 1000ms").Return(nil)
 

--- a/container/client_test.go
+++ b/container/client_test.go
@@ -542,7 +542,7 @@ func TestDisruptContainer_Success(t *testing.T) {
 	}
 
 	api := mockclient.NewMockClient()
-	//api.On("ExecCreate", mock.Anything).Return(nil)
+	api.On("ExecCreate", mock.Anything).Return(nil)
 	//api.On("ExecStart", "abc123", mock.Anything).Return(nil)
 	api.On("DisruptContainer", "abc123", "delay 1000ms").Return(nil)
 

--- a/container/client_test.go
+++ b/container/client_test.go
@@ -543,6 +543,8 @@ func TestDisruptContainer_Success(t *testing.T) {
 
 	api := mockclient.NewMockClient()
 	api.On("DisruptContainer", "abc123", "delay 1000ms").Return(nil)
+	api.On("ExecCreate", mock.Anything).Return(nil)
+	api.On("ExecStart", mock.Anything, mock.Anything).Return(nil)
 
 	client := dockerClient{api: api}
 	err := client.DisruptContainer(c, "delay 1000ms", false)
@@ -559,11 +561,12 @@ func TestDisruptContainer_DryRun(t *testing.T) {
 	}
 
 	api := mockclient.NewMockClient()
-	api.On("DisruptContainer", "abc123", "delay 1000ms").Return(nil)
 
 	client := dockerClient{api: api}
 	err := client.DisruptContainer(c, "delay 1000ms", true)
 
 	assert.NoError(t, err)
 	api.AssertNotCalled(t, "DisruptContainer", "abc123","delay 1000ms")
+	api.AssertNotCalled(t, "ExecCreate", mock.Anything)
+	api.AssertNotCalled(t, "ExecStart", mock.Anything, mock.Anything)
 }

--- a/container/mockclient/mock.go
+++ b/container/mockclient/mock.go
@@ -59,3 +59,9 @@ func (m *MockClient) PauseContainer(c container.Container, d time.Duration, dryr
 	args := m.Called(c, d)
 	return args.Error(0)
 }
+
+// PauseContainer mock
+func (m *MockClient) DisruptContainer(c container.Container, s string, dryrun bool) error {
+	args := m.Called(c, s)
+	return args.Error(0)
+}

--- a/main.go
+++ b/main.go
@@ -236,7 +236,7 @@ func createChaos(chaos actions.Chaos, args []string, limit int, test bool) error
 		// accordingly assign 2nd cmd line argument if exists
 		option := defaultKillSignal
 		if command == "DISRUPT" {
-			option := defaultNetemCmd
+			option = defaultNetemCmd
 		}
 		if len(cs) >= 2 {
 			option = cs[1]

--- a/main.go
+++ b/main.go
@@ -315,6 +315,7 @@ func createChaos(chaos actions.Chaos, args []string, limit int, test bool) error
 					err = chaos.DisruptByName(client, cmd.names, cmd.option)
 				} else {
 					err = chaos.DisruptByPattern(client, cmd.pattern,cmd.option)
+				}
 			case "PAUSE":
 				if cmd.pattern == "" {
 					err = chaos.PauseByName(client, cmd.names, cmd.option)

--- a/main.go
+++ b/main.go
@@ -246,7 +246,9 @@ func createChaos(chaos actions.Chaos, args []string, limit int, test bool) error
 					//  otherwise, just replace the netem command
 					if net.ParseIP(cs[1]) {
 						netemCmd = netemCmd + ":" + cs[1]
-					} else netemCmd = cs[1]
+					} else {
+						netemCmd = cs[1]
+					}
 				}
 				log.Debugf("Netem Command: '%s'", netemCmd)
 			} else {

--- a/main.go
+++ b/main.go
@@ -273,9 +273,9 @@ func createChaos(chaos actions.Chaos, args []string, limit int, test bool) error
 				}
 			case "DISRUPT":
 				if cmd.pattern == "" {
-					err = chaos.DisruptByName(client, cmd.names, true)
+					err = chaos.DisruptByName(client, cmd.names)
 				} else {
-					err = chaos.DisruptByPattern(client, cmd.pattern, true)
+					err = chaos.DisruptByPattern(client, cmd.pattern)
 				}
 			}
 			if err != nil {

--- a/main.go
+++ b/main.go
@@ -32,7 +32,7 @@ const (
 	defaultKillSignal = "SIGKILL"
 	re2prefix         = "re2:"
 	release           = "v0.1.10"
-	defaultNetemCmd   = "delay 100ms"
+	defaultNetemCmd   = "delay 1000ms"
 )
 
 type commandT struct {

--- a/main.go
+++ b/main.go
@@ -72,7 +72,7 @@ func main() {
 			Flags: []cli.Flag{
 				cli.StringSliceFlag{
 					Name:  "chaos, c",
-					Usage: "chaos command: `container(s,)/re2:regex|interval(s/m/h postfix)|STOP/KILL(:SIGNAL)/RM`",
+					Usage: "chaos command: `container(s,)/re2:regex|interval(s/m/h postfix)|STOP/KILL(:SIGNAL)/RM/DISRUPT`",
 				},
 				cli.BoolFlag{
 					Name:        "random, r",
@@ -85,7 +85,7 @@ func main() {
 					Destination: &actions.DryMode,
 				},
 			},
-			Usage:  "Pumba starts making chaos: periodically (and randomly) kills/stops/remove specified containers",
+			Usage:  "Pumba starts making chaos: periodically (and randomly) kills/stops/removes/disrupts specified containers",
 			Action: run,
 		},
 	}
@@ -218,8 +218,8 @@ func createChaos(chaos actions.Chaos, args []string, limit int, test bool) error
 		// get command and signal (if specified); convert everything to upper case
 		cs := strings.Split(strings.ToUpper(s[2]), ":")
 		command := cs[0]
-		if !stringInSlice(command, []string{"STOP", "KILL", "RM"}) {
-			return errors.New("Unexpected command in chaos option: can be STOP, KILL or RM")
+		if !stringInSlice(command, []string{"STOP", "KILL", "RM", "DISRUPT"}) {
+			return errors.New("Unexpected command in chaos option: can be STOP, KILL, RM or DISRUPT")
 		}
 		log.Debugf("Command: '%s'", command)
 		signal := defaultKillSignal
@@ -270,6 +270,12 @@ func createChaos(chaos actions.Chaos, args []string, limit int, test bool) error
 					err = chaos.RemoveByName(client, cmd.names, true)
 				} else {
 					err = chaos.RemoveByPattern(client, cmd.pattern, true)
+				}
+			case "DISRUPT":
+				if cmd.pattern == "" {
+					err = chaos.DisruptByName(client, cmd.names, true)
+				} else {
+					err = chaos.DisruptByPattern(client, cmd.pattern, true)
 				}
 			}
 			if err != nil {

--- a/main.go
+++ b/main.go
@@ -244,7 +244,7 @@ func createChaos(chaos actions.Chaos, args []string, limit int, test bool) error
 				} else {
 					// If it's IP, re-concat it with the default command
 					//  otherwise, just replace the netem command
-					if net.ParseIP(cs[1]) {
+					if net.ParseIP(cs[1]) != nil {
 						netemCmd = netemCmd + ":" + cs[1]
 					} else {
 						netemCmd = cs[1]

--- a/main.go
+++ b/main.go
@@ -229,18 +229,13 @@ func createChaos(chaos actions.Chaos, args []string, limit int, test bool) error
 		signal := defaultKillSignal
 		netemCmd := defaultNetemCmd
 		if len(cs) == 2 {
-			if (cs[0] == "STOP" || cs[0] == "KILL")
-			{
+			if cs[0] == "STOP" || cs[0] == "KILL" {
 				signal = cs[1]
 				log.Debugf("Signal: '%s'", signal)
-			}
-			else if (cs[0] == "DISRUPT")
-			{
+			} else if cs[0] == "DISRUPT" {
 				netemCmd = cs[1]
 				log.Debugf("Netem Command: '%s'", netemCmd)
-			}
-			else
-			{
+			} else {
 				log.Debugf("2nd argument doesn't correspond with command: '%s'", cs[1])	
 				return errors.New("Surplus 2nd argument to chaos action command")
 			}

--- a/main.go
+++ b/main.go
@@ -250,14 +250,14 @@ func createChaos(chaos actions.Chaos, args []string, limit int, test bool) error
 				if len(cs) == 3 {
 					// then we have both command and target IP, just need to put them 
 					//   together for the internal implementaion
-					option = option + ":" + cs[2]
+					option := cs[1] + ":" + cs[2]
 				} else {
 					// If it's IP, re-concat it with the default command
 					//  otherwise, just replace the netem command
 					if net.ParseIP(cs[1]) != nil {
-						option = option + ":" + cs[1]
+						option := option + ":" + cs[1]
 					} else {
-						option = cs[1]
+						option := cs[1]
 					}
 				}
 				log.Debugf("Netem Command: '%s'", option)

--- a/main.go
+++ b/main.go
@@ -235,15 +235,18 @@ func createChaos(chaos actions.Chaos, args []string, limit int, test bool) error
 		//	and DISRUPT:netem command:target ip
 		// accordingly assign 2nd cmd line argument if exists
 		option := defaultKillSignal
+		if command == "DISRUPT" {
+			option := defaultNetemCmd
+		}
 		if len(cs) >= 2 {
 			option = cs[1]
 			if command == "PAUSE" {
 				log.Debugf("Pause interval: '%s'", option)
-			} else if cs[0] == "STOP" || cs[0] == "KILL" {
+			} else if command == "STOP" || command == "KILL" {
 				// convert signal to UPPER
 				option := strings.ToUpper(option)
 				log.Debugf("Signal: '%s'", option)
-			} else if cs[0] == "DISRUPT" {
+			} else if command == "DISRUPT" {
 				option = defaultNetemCmd
 				// the string may be netem command or target IP - as the user
 				//  can omit the command part and use the default

--- a/main.go
+++ b/main.go
@@ -240,16 +240,13 @@ func createChaos(chaos actions.Chaos, args []string, limit int, test bool) error
 				if len(cs) == 3 {
 					// then we have both command and target IP, just need to put them 
 					//   together for the internal implementaion
-					netemCmd = cs[1] + ":" cs[2]
-				}
-				else {
+					netemCmd = cs[1] + ":" + cs[2]
+				} else {
 					// If it's IP, re-concat it with the default command
 					//  otherwise, just replace the netem command
 					if net.ParseIP(cs[1]) {
 						netemCmd = netemCmd + ":" + cs[1]
-					}
-					else
-						netemCmd = cs[1]
+					} else netemCmd = cs[1]
 				}
 				log.Debugf("Netem Command: '%s'", netemCmd)
 			} else {

--- a/main.go
+++ b/main.go
@@ -244,20 +244,20 @@ func createChaos(chaos actions.Chaos, args []string, limit int, test bool) error
 				option := strings.ToUpper(option)
 				log.Debugf("Signal: '%s'", option)
 			} else if cs[0] == "DISRUPT" {
-				option := defaultNetemCmd
+				option = defaultNetemCmd
 				// the string may be netem command or target IP - as the user
 				//  can omit the command part and use the default
 				if len(cs) == 3 {
 					// then we have both command and target IP, just need to put them 
 					//   together for the internal implementaion
-					option := cs[1] + ":" + cs[2]
+					option = cs[1] + ":" + cs[2]
 				} else {
 					// If it's IP, re-concat it with the default command
 					//  otherwise, just replace the netem command
 					if net.ParseIP(cs[1]) != nil {
-						option := option + ":" + cs[1]
+						option = option + ":" + cs[1]
 					} else {
-						option := cs[1]
+						option = cs[1]
 					}
 				}
 				log.Debugf("Netem Command: '%s'", option)

--- a/main_test.go
+++ b/main_test.go
@@ -55,6 +55,16 @@ func (m *ChaosMock) PauseByPattern(c container.Client, p string, i string) error
 	return args.Error(0)
 }
 
+func (m *ChaosMock) DisruptByName(c container.Client, n []string, cmd string) error {
+	args := m.Called(c, n, cmd)
+	return args.Error(0)
+}
+
+func (m *ChaosMock) DisruptByPattern(c container.Client, p string, cmd string) error {
+	args := m.Called(c, p, cmd)
+	return args.Error(0)
+}
+
 //---- TESTS
 
 func TestCreateChaos_StopByName(t *testing.T) {
@@ -172,6 +182,81 @@ func TestCreateChaos_RemoveByPattern(t *testing.T) {
 	chaos := &ChaosMock{}
 	for i := 0; i < limit; i++ {
 		chaos.On("RemoveByPattern", nil, "(abc)", true).Return(nil)
+	}
+
+	err := createChaos(chaos, []string{cmd}, limit, true)
+
+	assert.NoError(t, err)
+	chaos.AssertExpectations(t)
+}
+
+func TestCreateChaos_DisruptByName(t *testing.T) {
+	cmd := "cc1,cc2|10ms|DISRUPT"
+	limit := 3
+
+	chaos := &ChaosMock{}
+	for i := 0; i < limit; i++ {
+		chaos.On("DisruptByName", nil, []string{"cc1", "cc2"}, "delay 1000ms").Return(nil)
+	}
+
+	err := createChaos(chaos, []string{cmd}, limit, true)
+
+	assert.NoError(t, err)
+	chaos.AssertExpectations(t)
+}
+
+func TestCreateChaos_DisruptByNameCmd(t *testing.T) {
+	cmd := "cc1,cc2|10ms|DISRUPT:delay 3000ms"
+	limit := 3
+
+	chaos := &ChaosMock{}
+	for i := 0; i < limit; i++ {
+		chaos.On("DisruptByName", nil, []string{"cc1", "cc2"}, "delay 3000ms").Return(nil)
+	}
+
+	err := createChaos(chaos, []string{cmd}, limit, true)
+
+	assert.NoError(t, err)
+	chaos.AssertExpectations(t)
+}
+
+func TestCreateChaos_DisruptByNameIP(t *testing.T) {
+	cmd := "cc1,cc2|10ms|DISRUPT:172.19.0.3"
+	limit := 3
+
+	chaos := &ChaosMock{}
+	for i := 0; i < limit; i++ {
+		chaos.On("DisruptByName", nil, []string{"cc1", "cc2"}, "172.19.0.3").Return(nil)
+	}
+
+	err := createChaos(chaos, []string{cmd}, limit, true)
+
+	assert.NoError(t, err)
+	chaos.AssertExpectations(t)
+}
+
+func TestCreateChaos_DisruptByNameCmdAndIP(t *testing.T) {
+	cmd := "cc1,cc2|10ms|DISRUPT:delay 500ms:172.19.0.3"
+	limit := 3
+
+	chaos := &ChaosMock{}
+	for i := 0; i < limit; i++ {
+		chaos.On("DisruptByName", nil, []string{"cc1", "cc2"}, "delay 500ms:172.19.0.3").Return(nil)
+	}
+
+	err := createChaos(chaos, []string{cmd}, limit, true)
+
+	assert.NoError(t, err)
+	chaos.AssertExpectations(t)
+}
+
+func TestCreateChaos_DisruptByPattern(t *testing.T) {
+	cmd := "re2:(abc)|10ms|DISRUPT"
+	limit := 3
+
+	chaos := &ChaosMock{}
+	for i := 0; i < limit; i++ {
+		chaos.On("DisruptByPattern", nil, "(abc)", "delay 1000ms").Return(nil)
 	}
 
 	err := createChaos(chaos, []string{cmd}, limit, true)

--- a/main_test.go
+++ b/main_test.go
@@ -221,12 +221,12 @@ func TestCreateChaos_DisruptByNameCmd(t *testing.T) {
 }
 
 func TestCreateChaos_DisruptByNameIP(t *testing.T) {
-	cmd := "cc1,cc2|10ms|DISRUPT:172.19.0.3"
+	cmd := "cc1,cc2|10ms|DISRUPT:172.19.0.3" // will use the default netem command
 	limit := 3
 
 	chaos := &ChaosMock{}
 	for i := 0; i < limit; i++ {
-		chaos.On("DisruptByName", nil, []string{"cc1", "cc2"}, "172.19.0.3").Return(nil)
+		chaos.On("DisruptByName", nil, []string{"cc1", "cc2"}, "delay 1000ms:172.19.0.3").Return(nil)
 	}
 
 	err := createChaos(chaos, []string{cmd}, limit, true)


### PR DESCRIPTION
Use pumba to disrupt a container's network.
Missing capabilities:
- Remove disruption (currently has to be done manually with 'docker exec')
- Disrupt once (currently using Pumba interval, although it isn't relevant)
- Use 'qdisc change' verb instead of 'qdisc add' (requires Pumba state management to be aware of previous 'add' and use 'change' instead)