### PR TITLE
Pumba is now able to remove container

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,9 +121,9 @@ DESCRIPTION:
    remove target containers, with links and voluems
 
 OPTIONS:
-   --force, -f    force the removal of a running container (with SIGKILL)
-   --links, -l    remove container links
-   --volumes, -v  remove volumes associated with the container
+   --force, -f    force the removal of a running container (with SIGKILL, default: true)
+   --links, -l    remove container links (default: false)
+   --volumes, -v  remove volumes associated with the container (default: true)
 ```
 
 ### Network Emulation (netem) command

--- a/container/client.go
+++ b/container/client.go
@@ -146,8 +146,8 @@ func (client dockerClient) RemoveContainer(c Container, force bool, links bool, 
 	log.Infof("%sRemoving container %s", prefix, c.ID())
 	if !dryrun {
 		removeOpts := types.ContainerRemoveOptions{
-			RemoveVolumes: links,
-			RemoveLinks:   volumes,
+			RemoveVolumes: volumes,
+			RemoveLinks:   links,
 			Force:         force,
 		}
 		return client.containerAPI.ContainerRemove(apiContext(), c.ID(), removeOpts)

--- a/main.go
+++ b/main.go
@@ -351,7 +351,7 @@ func main() {
 					Name:  "force, f",
 					Usage: "force the removal of a running container (with SIGKILL)",
 				},
-				cli.BoolTFlag{
+				cli.BoolFlag{
 					Name:  "links, l",
 					Usage: "remove container links",
 				},
@@ -872,6 +872,7 @@ func remove(c *cli.Context) error {
 	links := c.BoolT("links")
 	// get link flag
 	volumes := c.BoolT("volumes")
+
 	// run chaos command
 	cmd := action.CommandRemove{Force: force, Links: links, Volumes: volumes}
 	runChaosCommand(cmd, names, pattern, chaos.RemoveContainers)

--- a/tests/remove_container.bats
+++ b/tests/remove_container.bats
@@ -1,0 +1,16 @@
+#!/usr/bin/env bats
+
+@test "Should remove running docker container without any parameters" {
+    # given (started container)
+    docker run -dit --name victim alpine ping localhost
+
+    # when (trying to remove container)
+    run pumba rm victim
+
+    # then (pumba exited successfully)
+    [ $status -eq 0 ]
+
+    # and (container has been removed)
+    run bash -c "docker ps -a | grep victim"
+    [ ! "$output" ]
+}


### PR DESCRIPTION
It seems like --links should be disabled by default. Here's why:
https://github.com/docker/docker/blob/master/daemon/delete.go

If a parent path of a container is '/', which is, I suppose, the case when you're trying to remove a container that is started outside a docker compose, it's not able to delete it with links. 

I've fixed a typo (volumes and links mismatch) and added 1 tests to prove it now works.