### PR TITLE
fix logging of configs

### DIFF
--- a/container/client.go
+++ b/container/client.go
@@ -377,7 +377,7 @@ func (client dockerClient) tcContainerCommand(ctx context.Context, target Contai
 		Cmd:        args,
 		Image:      tcimage,
 	}
-	log.Debugf("Container Config: %s", config)
+	log.Debugf("Container Config: %+v", config)
 	// host config
 	hconfig := ctypes.HostConfig{
 		// auto remove container on tc command exit
@@ -392,7 +392,7 @@ func (client dockerClient) tcContainerCommand(ctx context.Context, target Contai
 		DNSOptions:   []string{},
 		DNSSearch:    []string{},
 	}
-	log.Debugf("Host Config: %s", hconfig)
+	log.Debugf("Host Config: %+v", hconfig)
 	createResponse, err := client.containerAPI.ContainerCreate(ctx, &config, &hconfig, nil, "")
 	if err != nil {
 		return err


### PR DESCRIPTION
format structs properly; in particular also show the property names
```
BEFORE:
time="2017-11-14T22:17:46Z" level=debug msg="Container Config: {   %!s(bool=false) %!s(bool=false) %!s(bool=false) map[] %!s(bool=false) %!s(bool=false) %!s(bool=false) [] [qdisc add dev eth0 root netem loss 100.00] %!s(*container.HealthConfig=<nil>) %!s(bool=false) gaiadocker/iproute2 map[]  [tc] %!s(bool=false)  [] map[com.gaiaadm.pumba.skip:true]  %!s(*int=<nil>) []}"
time="2017-11-14T22:18:16Z" level=debug msg="Host Config: {[]  { map[]} container:63ac172fcb75d1383327ea2dba057aba2f8befad24f40271292f1d0a28e524ff map[] { %!s(int=0)} %!s(bool=true)  [] [NET_ADMIN] [] [] [] [] [] []   [] %!s(int=0)  %!s(bool=false) %!s(bool=false) %!s(bool=false) [] map[] map[]   %!s(int64=0) map[]  [%!s(uint=0) %!s(uint=0)]  {%!s(int64=0) %!s(int64=0) %!s(int64=0)  %!s(uint16=0) [] [] [] [] [] %!s(int64=0) %!s(int64=0) %!s(int64=0) %!s(int64=0)   [] %!s(int64=0) %!s(int64=0) %!s(int64=0) %!s(int64=0) %!s(*int64=<nil>) %!s(*bool=<nil>) %!s(int64=0) [] %!s(int64=0) %!s(int64=0) %!s(uint64=0) %!s(uint64=0)} [] %!s(*bool=<nil>) }"

AFTER:
time="2017-11-14T22:46:17Z" level=debug msg="Container Config: {Hostname: Domainname: User: AttachStdin:false AttachStdout:false AttachStderr:false ExposedPorts:map[] Tty:false OpenStdin:false StdinOnce:false Env:[] Cmd:[qdisc add dev eth0 root netem loss 100.00] Healthcheck:<nil> ArgsEscaped:false Image:gaiadocker/iproute2 Volumes:map[] WorkingDir: Entrypoint:[tc] NetworkDisabled:false MacAddress: OnBuild:[] Labels:map[com.gaiaadm.pumba.skip:true] StopSignal: StopTimeout:<nil> Shell:[]}"
time="2017-11-14T22:46:47Z" level=debug msg="Host Config: {Binds:[] ContainerIDFile: LogConfig:{Type: Config:map[]} NetworkMode:container:b13e81a44e77489b02dda02a9fc9eda27ebd4bb96c0c9d8a9173272958af448a PortBindings:map[] RestartPolicy:{Name: MaximumRetryCount:0} AutoRemove:true VolumeDriver: VolumesFrom:[] CapAdd:[NET_ADMIN] CapDrop:[] DNS:[] DNSOptions:[] DNSSearch:[] ExtraHosts:[] GroupAdd:[] IpcMode: Cgroup: Links:[] OomScoreAdj:0 PidMode: Privileged:false PublishAllPorts:false ReadonlyRootfs:false SecurityOpt:[] StorageOpt:map[] Tmpfs:map[] UTSMode: UsernsMode: ShmSize:0 Sysctls:map[] Runtime: ConsoleSize:[0 0] Isolation: Resources:{CPUShares:0 Memory:0 NanoCPUs:0 CgroupParent: BlkioWeight:0 BlkioWeightDevice:[] BlkioDeviceReadBps:[] BlkioDeviceWriteBps:[] BlkioDeviceReadIOps:[] BlkioDeviceWriteIOps:[] CPUPeriod:0 CPUQuota:0 CPURealtimePeriod:0 CPURealtimeRuntime:0 CpusetCpus: CpusetMems: Devices:[] DiskQuota:0 KernelMemory:0 MemoryReservation:0 MemorySwap:0 MemorySwappiness:<nil> OomKillDisable:<nil> PidsLimit:0 Ulimits:[] CPUCount:0 CPUPercent:0 IOMaximumIOps:0 IOMaximumBandwidth:0} Mounts:[] Init:<nil> InitPath:}"
```