### PR TITLE
support specifying multiple target IP's

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ COMMANDS:
 OPTIONS:
    --duration value, -d value   network emulation duration; should be smaller than recurrent interval; use with optional unit suffix: 'ms/s/m/h'
    --interface value, -i value  network interface to apply delay on (default: "eth0")
-   --target value, -t value     target IP filter; netem will impact only on traffic to target IP
+   --target value, -t value     target IP filter; comma separated. netem will impact only on traffic to target IP(s)
    --tc-image value             Docker image with tc (iproute2 package); try 'gaiadocker/iproute2'
    --help, -h                   show help
 ```

--- a/action/chaos_test.go
+++ b/action/chaos_test.go
@@ -414,7 +414,7 @@ func TestNetemDelayByName(t *testing.T) {
 	names, cs := makeContainersN(10)
 	cmd := CommandNetemDelay{
 		NetInterface: "eth1",
-		IP:           nil,
+		IPs:          nil,
 		Duration:     1 * time.Millisecond,
 		Time:         120,
 		Jitter:       25,
@@ -423,8 +423,8 @@ func TestNetemDelayByName(t *testing.T) {
 	client := container.NewMockClient()
 	client.On("ListContainers", mock.Anything, mock.Anything).Return(cs, nil)
 	for _, c := range cs {
-		client.On("NetemContainer", mock.Anything, c, "eth1", []string{"delay", "120ms", "25ms", "0.23"}, net.ParseIP(""), 1*time.Millisecond, "").Return(nil)
-		client.On("StopNetemContainer", mock.Anything, c, "eth1", net.ParseIP(""), "").Return(nil)
+		client.On("NetemContainer", mock.Anything, c, "eth1", []string{"delay", "120ms", "25ms", "0.23"}, []net.IP(nil), 1*time.Millisecond, "").Return(nil)
+		client.On("StopNetemContainer", mock.Anything, c, "eth1", []net.IP(nil), "").Return(nil)
 	}
 	// do action
 	pumba := pumbaChaos{}
@@ -439,7 +439,7 @@ func TestNetemDelayByNameRandom(t *testing.T) {
 	names, cs := makeContainersN(10)
 	cmd := CommandNetemDelay{
 		NetInterface: "eth1",
-		IP:           nil,
+		IPs:          nil,
 		Duration:     1 * time.Millisecond,
 		Time:         120,
 		Jitter:       25,
@@ -448,8 +448,8 @@ func TestNetemDelayByNameRandom(t *testing.T) {
 	}
 	client := container.NewMockClient()
 	client.On("ListContainers", mock.Anything, mock.Anything).Return(cs, nil)
-	client.On("NetemContainer", mock.Anything, mock.Anything, "eth1", []string{"delay", "120ms", "25ms", "5.50", "distribution", "uniform"}, net.ParseIP(""), 1*time.Millisecond, "").Return(nil)
-	client.On("StopNetemContainer", mock.Anything, mock.Anything, "eth1", net.ParseIP(""), "").Return(nil)
+	client.On("NetemContainer", mock.Anything, mock.Anything, "eth1", []string{"delay", "120ms", "25ms", "5.50", "distribution", "uniform"}, []net.IP(nil), 1*time.Millisecond, "").Return(nil)
+	client.On("StopNetemContainer", mock.Anything, mock.Anything, "eth1", []net.IP(nil), "").Return(nil)
 	// do action
 	RandomMode = true
 	pumba := pumbaChaos{}
@@ -465,7 +465,7 @@ func TestNetemDelayByPattern(t *testing.T) {
 	_, cs := makeContainersN(10)
 	cmd := CommandNetemDelay{
 		NetInterface: "eth1",
-		IP:           nil,
+		IPs:          nil,
 		Duration:     1 * time.Millisecond,
 		Time:         120,
 		Jitter:       25,
@@ -474,8 +474,8 @@ func TestNetemDelayByPattern(t *testing.T) {
 	client := container.NewMockClient()
 	client.On("ListContainers", mock.Anything, mock.Anything).Return(cs, nil)
 	for _, c := range cs {
-		client.On("NetemContainer", mock.Anything, c, "eth1", []string{"delay", "120ms", "25ms", "15.00"}, net.ParseIP(""), 1*time.Millisecond, "").Return(nil)
-		client.On("StopNetemContainer", mock.Anything, c, "eth1", net.ParseIP(""), "").Return(nil)
+		client.On("NetemContainer", mock.Anything, c, "eth1", []string{"delay", "120ms", "25ms", "15.00"}, []net.IP(nil), 1*time.Millisecond, "").Return(nil)
+		client.On("StopNetemContainer", mock.Anything, c, "eth1", []net.IP(nil), "").Return(nil)
 	}
 	// do action
 	pumba := pumbaChaos{}
@@ -488,10 +488,10 @@ func TestNetemDelayByPattern(t *testing.T) {
 func TestNetemDelayByPatternIPFilter(t *testing.T) {
 	// prepare test data and mocks
 	_, cs := makeContainersN(10)
-	ip := net.ParseIP("10.10.0.1")
+	ips := []net.IP{net.ParseIP("10.10.0.1")}
 	cmd := CommandNetemDelay{
 		NetInterface: "eth1",
-		IP:           ip,
+		IPs:          ips,
 		Duration:     1 * time.Millisecond,
 		Time:         120,
 		Jitter:       25,
@@ -500,8 +500,8 @@ func TestNetemDelayByPatternIPFilter(t *testing.T) {
 	client := container.NewMockClient()
 	client.On("ListContainers", mock.Anything, mock.Anything).Return(cs, nil)
 	for _, c := range cs {
-		client.On("NetemContainer", mock.Anything, c, "eth1", []string{"delay", "120ms", "25ms", "10.00"}, ip, 1*time.Millisecond, "").Return(nil)
-		client.On("StopNetemContainer", mock.Anything, c, "eth1", ip, "").Return(nil)
+		client.On("NetemContainer", mock.Anything, c, "eth1", []string{"delay", "120ms", "25ms", "10.00"}, ips, 1*time.Millisecond, "").Return(nil)
+		client.On("StopNetemContainer", mock.Anything, c, "eth1", ips, "").Return(nil)
 	}
 	// do action
 	pumba := pumbaChaos{}
@@ -516,7 +516,7 @@ func TestNetemDelayByPatternRandom(t *testing.T) {
 	_, cs := makeContainersN(10)
 	cmd := CommandNetemDelay{
 		NetInterface: "eth1",
-		IP:           nil,
+		IPs:          nil,
 		Duration:     1 * time.Millisecond,
 		Time:         120,
 		Jitter:       25,
@@ -524,8 +524,8 @@ func TestNetemDelayByPatternRandom(t *testing.T) {
 	}
 	client := container.NewMockClient()
 	client.On("ListContainers", mock.Anything, mock.Anything).Return(cs, nil)
-	client.On("NetemContainer", mock.Anything, mock.Anything, "eth1", []string{"delay", "120ms", "25ms", "10.20"}, net.ParseIP(""), 1*time.Millisecond, "").Return(nil)
-	client.On("StopNetemContainer", mock.Anything, mock.Anything, "eth1", net.ParseIP(""), "").Return(nil)
+	client.On("NetemContainer", mock.Anything, mock.Anything, "eth1", []string{"delay", "120ms", "25ms", "10.20"}, []net.IP(nil), 1*time.Millisecond, "").Return(nil)
+	client.On("StopNetemContainer", mock.Anything, mock.Anything, "eth1", []net.IP(nil), "").Return(nil)
 	// do action
 	RandomMode = true
 	pumba := pumbaChaos{}
@@ -541,7 +541,7 @@ func TestNetemLossByName(t *testing.T) {
 	names, cs := makeContainersN(10)
 	cmd := CommandNetemLossRandom{
 		NetInterface: "eth1",
-		IP:           nil,
+		IPs:          nil,
 		Duration:     1 * time.Millisecond,
 		Percent:      11.5,
 		Correlation:  25.53,
@@ -549,8 +549,8 @@ func TestNetemLossByName(t *testing.T) {
 	client := container.NewMockClient()
 	client.On("ListContainers", mock.Anything, mock.Anything).Return(cs, nil)
 	for _, c := range cs {
-		client.On("NetemContainer", mock.Anything, c, "eth1", []string{"loss", "11.50", "25.53"}, net.ParseIP(""), 1*time.Millisecond, "").Return(nil)
-		client.On("StopNetemContainer", mock.Anything, c, "eth1", net.ParseIP(""), "").Return(nil)
+		client.On("NetemContainer", mock.Anything, c, "eth1", []string{"loss", "11.50", "25.53"}, []net.IP(nil), 1*time.Millisecond, "").Return(nil)
+		client.On("StopNetemContainer", mock.Anything, c, "eth1", []net.IP(nil), "").Return(nil)
 	}
 	// do action
 	pumba := pumbaChaos{}
@@ -581,7 +581,7 @@ func TestNetemLossStateByName(t *testing.T) {
 	names, cs := makeContainersN(10)
 	cmd := CommandNetemLossState{
 		NetInterface: "eth1",
-		IP:           nil,
+		IPs:          nil,
 		Duration:     1 * time.Millisecond,
 		P13:          11.5,
 		P31:          12.6,
@@ -592,8 +592,8 @@ func TestNetemLossStateByName(t *testing.T) {
 	client := container.NewMockClient()
 	client.On("ListContainers", mock.Anything, mock.Anything).Return(cs, nil)
 	for _, c := range cs {
-		client.On("NetemContainer", mock.Anything, c, "eth1", []string{"loss", "state", "11.50", "12.60", "13.70", "14.80", "15.90"}, net.ParseIP(""), 1*time.Millisecond, "").Return(nil)
-		client.On("StopNetemContainer", mock.Anything, c, "eth1", net.ParseIP(""), "").Return(nil)
+		client.On("NetemContainer", mock.Anything, c, "eth1", []string{"loss", "state", "11.50", "12.60", "13.70", "14.80", "15.90"}, []net.IP(nil), 1*time.Millisecond, "").Return(nil)
+		client.On("StopNetemContainer", mock.Anything, c, "eth1", []net.IP(nil), "").Return(nil)
 	}
 	// do action
 	pumba := pumbaChaos{}
@@ -624,7 +624,7 @@ func TestNetemLossGEmodelByName(t *testing.T) {
 	names, cs := makeContainersN(10)
 	cmd := CommandNetemLossGEmodel{
 		NetInterface: "eth1",
-		IP:           nil,
+		IPs:          nil,
 		Duration:     1 * time.Millisecond,
 		PG:           11.5,
 		PB:           12.6,
@@ -634,8 +634,8 @@ func TestNetemLossGEmodelByName(t *testing.T) {
 	client := container.NewMockClient()
 	client.On("ListContainers", mock.Anything, mock.Anything).Return(cs, nil)
 	for _, c := range cs {
-		client.On("NetemContainer", mock.Anything, c, "eth1", []string{"loss", "gemodel", "11.50", "12.60", "13.70", "14.80"}, net.ParseIP(""), 1*time.Millisecond, "").Return(nil)
-		client.On("StopNetemContainer", mock.Anything, c, "eth1", net.ParseIP(""), "").Return(nil)
+		client.On("NetemContainer", mock.Anything, c, "eth1", []string{"loss", "gemodel", "11.50", "12.60", "13.70", "14.80"}, []net.IP(nil), 1*time.Millisecond, "").Return(nil)
+		client.On("StopNetemContainer", mock.Anything, c, "eth1", []net.IP(nil), "").Return(nil)
 	}
 	// do action
 	pumba := pumbaChaos{}
@@ -666,7 +666,7 @@ func TestNetemRateByName(t *testing.T) {
 	names, cs := makeContainersN(10)
 	cmd := CommandNetemRate{
 		NetInterface:   "eth1",
-		IP:             nil,
+		IPs:            nil,
 		Duration:       1 * time.Millisecond,
 		Rate:           "300kbit",
 		PacketOverhead: 10,
@@ -676,8 +676,8 @@ func TestNetemRateByName(t *testing.T) {
 	client := container.NewMockClient()
 	client.On("ListContainers", mock.Anything, mock.Anything).Return(cs, nil)
 	for _, c := range cs {
-		client.On("NetemContainer", mock.Anything, c, "eth1", []string{"rate", "300kbit", "10", "20", "30"}, net.ParseIP(""), 1*time.Millisecond, "").Return(nil)
-		client.On("StopNetemContainer", mock.Anything, c, "eth1", net.ParseIP(""), "").Return(nil)
+		client.On("NetemContainer", mock.Anything, c, "eth1", []string{"rate", "300kbit", "10", "20", "30"}, []net.IP(nil), 1*time.Millisecond, "").Return(nil)
+		client.On("StopNetemContainer", mock.Anything, c, "eth1", []net.IP(nil), "").Return(nil)
 	}
 	// do action
 	pumba := pumbaChaos{}

--- a/container/client_test.go
+++ b/container/client_test.go
@@ -468,7 +468,7 @@ func TestNetemContainerIPFilter_Success(t *testing.T) {
 	engineClient.On("ContainerExecInspect", ctx, "cmd5").Return(types.ContainerExecInspect{}, nil)
 
 	client := dockerClient{containerAPI: engineClient}
-	err := client.NetemContainer(context.TODO(), c, "eth0", []string{"delay", "500ms"}, net.ParseIP("10.10.0.1"), 1*time.Millisecond, "", false)
+	err := client.NetemContainer(context.TODO(), c, "eth0", []string{"delay", "500ms"}, []net.IP{net.ParseIP("10.10.0.1")}, 1*time.Millisecond, "", false)
 
 	assert.NoError(t, err)
 	engineClient.AssertExpectations(t)

--- a/container/mock.go
+++ b/container/mock.go
@@ -55,13 +55,13 @@ func (m *MockClient) UnpauseContainer(ctx context.Context, c Container, dryrun b
 }
 
 // NetemContainer mock
-func (m *MockClient) NetemContainer(ctx context.Context, c Container, n string, s []string, ip net.IP, d time.Duration, image string, dryrun bool) error {
-	args := m.Called(ctx, c, n, s, ip, d, image)
+func (m *MockClient) NetemContainer(ctx context.Context, c Container, n string, s []string, ips []net.IP, d time.Duration, image string, dryrun bool) error {
+	args := m.Called(ctx, c, n, s, ips, d, image)
 	return args.Error(0)
 }
 
 // StopNetemContainer mock
-func (m *MockClient) StopNetemContainer(ctx context.Context, c Container, n string, ip net.IP, image string, dryrun bool) error {
-	args := m.Called(ctx, c, n, ip, image)
+func (m *MockClient) StopNetemContainer(ctx context.Context, c Container, n string, ips []net.IP, image string, dryrun bool) error {
+	args := m.Called(ctx, c, n, ips, image)
 	return args.Error(0)
 }

--- a/main.go
+++ b/main.go
@@ -589,14 +589,17 @@ func parseNetemOptions(c *cli.Context) ([]string, string, time.Duration, string,
 			return names, pattern, duration, "", nil, "", err
 		}
 		// get target IP Filter
-		for _, str := range strings.Split(c.Parent().String("target"), ",") {
-			ip := net.ParseIP(str)
-			if ip == nil {
-				err = fmt.Errorf("Bad target specification. could not parse '%s' as an ip", str)
-				log.Error(err)
-				return names, pattern, duration, "", ips, "", err
+		target := c.Parent().String("target")
+		if target != "" {
+			for _, str := range strings.Split(target, ",") {
+				ip := net.ParseIP(str)
+				if ip == nil {
+					err = fmt.Errorf("Bad target specification. could not parse '%s' as an ip", str)
+					log.Error(err)
+					return names, pattern, duration, "", ips, "", err
+				}
+				ips = append(ips, ip)
 			}
-			ips = append(ips, ip)
 		}
 	}
 	// get Docker image with tc (iproute2 package)

--- a/main.go
+++ b/main.go
@@ -500,7 +500,6 @@ func runChaosCommand(cmd interface{}, interval time.Duration, names []string, pa
 	if interval == 0 {
 		tick = time.NewTimer(interval).C
 	} else {
-		fmt.Println("HERE!!!!")
 		tick = time.NewTicker(interval).C
 	}
 

--- a/main.go
+++ b/main.go
@@ -147,7 +147,7 @@ func main() {
 				},
 				cli.StringFlag{
 					Name:  "target, t",
-					Usage: "target IP filter; netem will impact only on traffic to target IP",
+					Usage: "target IP filter; comma separated. netem will impact only on traffic to target IP(s)",
 				},
 				cli.StringFlag{
 					Name:  "tc-image",
@@ -547,7 +547,7 @@ func kill(c *cli.Context) error {
 	return nil
 }
 
-func parseNetemOptions(c *cli.Context) ([]string, string, time.Duration, string, net.IP, string, error) {
+func parseNetemOptions(c *cli.Context) ([]string, string, time.Duration, string, []net.IP, string, error) {
 	// get names or pattern
 	names, pattern := getNamesOrPattern(c)
 	// get interval
@@ -576,9 +576,9 @@ func parseNetemOptions(c *cli.Context) ([]string, string, time.Duration, string,
 		log.Error(err)
 		return names, pattern, 0, "", nil, "", err
 	}
-	// get network interface and target ip
+	// get network interface and target ip(s)
 	netInterface := DefaultInterface
-	var ip net.IP
+	var ips []net.IP
 	if c.Parent() != nil {
 		netInterface = c.Parent().String("interface")
 		// protect from Command Injection, using Regexp
@@ -590,14 +590,22 @@ func parseNetemOptions(c *cli.Context) ([]string, string, time.Duration, string,
 			return names, pattern, duration, "", nil, "", err
 		}
 		// get target IP Filter
-		ip = net.ParseIP(c.Parent().String("target"))
+		for _, str := range strings.Split(c.Parent().String("target"), ",") {
+			ip := net.ParseIP(str)
+			if ip == nil {
+				err = fmt.Errorf("Bad target specification. could not parse '%s' as an ip", str)
+				log.Error(err)
+				return names, pattern, duration, "", ips, "", err
+			}
+			ips = append(ips, ip)
+		}
 	}
 	// get Docker image with tc (iproute2 package)
 	var image string
 	if c.Parent() != nil {
 		image = c.Parent().String("tc-image")
 	}
-	return names, pattern, duration, netInterface, ip, image, nil
+	return names, pattern, duration, netInterface, ips, image, nil
 }
 
 // NETEM DELAY command
@@ -608,7 +616,7 @@ func netemDelay(c *cli.Context) error {
 		return err
 	}
 	// parse common netem options
-	names, pattern, duration, netInterface, ip, image, err := parseNetemOptions(c)
+	names, pattern, duration, netInterface, ips, image, err := parseNetemOptions(c)
 	if err != nil {
 		return err
 	}
@@ -643,7 +651,7 @@ func netemDelay(c *cli.Context) error {
 	// pepare netem delay command
 	delayCmd := action.CommandNetemDelay{
 		NetInterface: netInterface,
-		IP:           ip,
+		IPs:          ips,
 		Duration:     duration,
 		Time:         time,
 		Jitter:       jitter,
@@ -663,7 +671,7 @@ func netemLossRandom(c *cli.Context) error {
 		return err
 	}
 	// parse common netem options
-	names, pattern, duration, netInterface, ip, image, err := parseNetemOptions(c)
+	names, pattern, duration, netInterface, ips, image, err := parseNetemOptions(c)
 	if err != nil {
 		return err
 	}
@@ -684,7 +692,7 @@ func netemLossRandom(c *cli.Context) error {
 	// pepare netem loss command
 	delayCmd := action.CommandNetemLossRandom{
 		NetInterface: netInterface,
-		IP:           ip,
+		IPs:          ips,
 		Duration:     duration,
 		Percent:      percent,
 		Correlation:  correlation,
@@ -702,7 +710,7 @@ func netemLossState(c *cli.Context) error {
 		return err
 	}
 	// parse common netem options
-	names, pattern, duration, netInterface, ip, image, err := parseNetemOptions(c)
+	names, pattern, duration, netInterface, ips, image, err := parseNetemOptions(c)
 	if err != nil {
 		return err
 	}
@@ -744,7 +752,7 @@ func netemLossState(c *cli.Context) error {
 	// pepare netem loss command
 	delayCmd := action.CommandNetemLossState{
 		NetInterface: netInterface,
-		IP:           ip,
+		IPs:          ips,
 		Duration:     duration,
 		P13:          p13,
 		P31:          p31,
@@ -765,7 +773,7 @@ func netemLossGEmodel(c *cli.Context) error {
 		return err
 	}
 	// parse common netem options
-	names, pattern, duration, netInterface, ip, image, err := parseNetemOptions(c)
+	names, pattern, duration, netInterface, ips, image, err := parseNetemOptions(c)
 	if err != nil {
 		return err
 	}
@@ -800,7 +808,7 @@ func netemLossGEmodel(c *cli.Context) error {
 	// pepare netem loss command
 	delayCmd := action.CommandNetemLossGEmodel{
 		NetInterface: netInterface,
-		IP:           ip,
+		IPs:          ips,
 		Duration:     duration,
 		PG:           pg,
 		PB:           pb,
@@ -820,7 +828,7 @@ func netemRate(c *cli.Context) error {
 		return err
 	}
 	// parse common netem options
-	names, pattern, duration, netInterface, ip, image, err := parseNetemOptions(c)
+	names, pattern, duration, netInterface, ips, image, err := parseNetemOptions(c)
 	if err != nil {
 		return err
 	}
@@ -850,7 +858,7 @@ func netemRate(c *cli.Context) error {
 	// pepare netem rate command
 	rateCmd := action.CommandNetemRate{
 		NetInterface:   netInterface,
-		IP:             ip,
+		IPs:            ips,
 		Duration:       duration,
 		Rate:           rate,
 		PacketOverhead: packetOverhead,


### PR DESCRIPTION
we now parse multiple ip's, comma separated.

also: validate ip's early on. previously we would silently ignore ip
parse errors

fix #57 

note: still need to test further, but this shows how i go about it.