### PR TITLE
do not spam extra shell / make killing soft by default

### DIFF
--- a/deploy/pumba_kube.yml
+++ b/deploy/pumba_kube.yml
@@ -23,10 +23,9 @@ spec:
       - image: gaiaadm/pumba:master
         imagePullPolicy: Always
         name: pumba
-# Pumba command: modify it to suite your needs
-# Currently: randomly try to kill some container every 3 minutes
-        command:
-          - "pumba --debug --random --interval 3m kill --signal SIGKILL"
+        # Pumba command: modify it to suite your needs
+        # Currently: randomly try to kill some container every 3 minutes
+        command: ["pumba", "--debug", "--random", "--interval", "3m", "kill", "--signal", "SIGTERM"]
         resources:
           requests:
             cpu: 10m


### PR DESCRIPTION
killing with -9 can have bad side-effects, let users opt-in that really want it instead of making it the default for copy-pasters

solves https://github.com/gaia-adm/pumba/issues/63

@Dieterbe 