### PR TITLE
prefer regular nodes by default

### DIFF
--- a/deploy/pumba_kube.yml
+++ b/deploy/pumba_kube.yml
@@ -34,6 +34,9 @@ spec:
           limits:
             cpu: 100m
             memory: 20M
+        # run on regular nodes and not api nodes where the critical infrastucure like kube-scheduler lives
+        nodeSelector:
+          node-type: node
         volumeMounts:
           - name: dockersocket
             mountPath: /var/run/docker.sock


### PR DESCRIPTION
killing things on the api nodes might have really bad side-effects, so let users opt in to that

@Dieterbe 