### PR TITLE
add requests/limits so container does not be come too greedy

### DIFF
--- a/deploy/pumba_kube.yml
+++ b/deploy/pumba_kube.yml
@@ -26,6 +26,13 @@ spec:
 # Currently: randomly try to kill some container every 3 minutes
         command:
           - "pumba --debug --random --interval 3m kill --signal SIGKILL"
+        resources:
+          requests:
+            cpu: 10m
+            memory: 5M
+          limits:
+            cpu: 100m
+            memory: 20M
         volumeMounts:
           - name: dockersocket
             mountPath: /var/run/docker.sock


### PR DESCRIPTION
seems to normally use 4m ... so 20max should be fine ...

![screen shot 2017-12-18 at 4 09 59 pm](https://user-images.githubusercontent.com/11367/34134199-13c0a12c-e40e-11e7-8555-ed31f579afd0.png)

solves https://github.com/gaia-adm/pumba/issues/61
